### PR TITLE
Quote types

### DIFF
--- a/.gometalinterrc
+++ b/.gometalinterrc
@@ -1,0 +1,5 @@
+{
+  "DisableAll": true,
+  "Enable": ["vet", "vetshadow", "golint", "ineffassign", "goconst"],
+  "Tests": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+  - 1.7.4
+  - tip
+
+before_install:
+  - go get -u github.com/distributeddesigns/currency
+  - go get -u github.com/alecthomas/gometalinter
+  - gometalinter --install
+
+install:
+  - go build .
+
+script:
+  - go test -v -cover
+  - gometalinter --config=.gometalinterrc ./...
+
+notifications:
+  email: false

--- a/quote.go
+++ b/quote.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/distributeddesigns/currency"
+)
+
+// Quote : Response from the quoteserver
+type Quote struct {
+	UserID    string
+	Stock     string
+	Price     currency.Currency
+	Timestamp time.Time
+	Cryptokey string
+}
+
+// ToCSV : Serialize the Quote as a CSV
+func (q *Quote) ToCSV() string {
+	parts := make([]string, 5)
+
+	parts[0] = q.UserID
+	parts[1] = q.Stock
+	parts[2] = fmt.Sprintf("%.02f", q.Price.ToFloat())
+	parts[3] = fmt.Sprintf("%d", q.Timestamp.UnixNano()/1000)
+	parts[4] = q.Cryptokey
+
+	return strings.Join(parts, ",")
+}
+
+// ParseQuote : Attempt to parse the CSV as a Quote
+func ParseQuote(csv string) (Quote, error) {
+	// remove messiness
+	csv = strings.TrimSpace(csv)
+
+	parts := strings.Split(csv, ",")
+
+	if len(parts) != 5 {
+		return Quote{}, errors.New("Expected 5 values in Quote csv")
+	}
+
+	price, err := currency.NewFromString(parts[2])
+	if err != nil {
+		return Quote{}, err
+	}
+
+	// Unix time has to be converted string -> int -> Time
+	milliSec, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return Quote{}, err
+	}
+
+	sec := milliSec / 1e6
+	nano := milliSec % 1e6 * 1000
+
+	quote := Quote{
+		UserID:    parts[0],
+		Stock:     parts[1],
+		Price:     price,
+		Timestamp: time.Unix(sec, nano),
+		Cryptokey: parts[4],
+	}
+
+	return quote, nil
+}

--- a/quoteRequest.go
+++ b/quoteRequest.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"errors"
+	"strings"
+)
+
+// QuoteRequest : Request for a quote value
+type QuoteRequest struct {
+	Stock  string
+	UserID string
+}
+
+// ToCSV : Converts the QuoteRequest to a csv
+func (qr *QuoteRequest) ToCSV() string {
+	return qr.Stock + "," + qr.UserID
+}
+
+// ParseQuoteRequest : Parses CSV as QuoteRequest
+func ParseQuoteRequest(csv string) (QuoteRequest, error) {
+	parts := strings.Split(csv, ",")
+	if len(parts) != 2 {
+		return QuoteRequest{}, errors.New("Expected 2 values in QuoteRequest csv")
+	}
+
+	return QuoteRequest{Stock: parts[0], UserID: parts[1]}, nil
+}

--- a/quoteRequest_test.go
+++ b/quoteRequest_test.go
@@ -1,0 +1,94 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestQuoteRequest_ToCSV(t *testing.T) {
+	const (
+		stock  = "AAPL"
+		userID = "jappleseed"
+	)
+
+	type fields struct {
+		Stock  string
+		UserID string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{stock, userID},
+			want:   stock + "," + userID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qr := &QuoteRequest{
+				Stock:  tt.fields.Stock,
+				UserID: tt.fields.UserID,
+			}
+			if got := qr.ToCSV(); got != tt.want {
+				t.Errorf("QuoteRequest.ToCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseQuoteRequest(t *testing.T) {
+	const (
+		stock  = "AAPL"
+		userID = "jappleseed"
+	)
+
+	type args struct {
+		csv string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    QuoteRequest
+		wantErr bool
+	}{
+		{
+			name:    "Happy path",
+			args:    args{stock + "," + userID},
+			want:    QuoteRequest{stock, userID},
+			wantErr: false,
+		},
+		{
+			name:    "Empty string",
+			args:    args{""},
+			want:    QuoteRequest{},
+			wantErr: true,
+		},
+		{
+			name:    "Too many args",
+			args:    args{"AAPL,jsmith,12345"},
+			want:    QuoteRequest{},
+			wantErr: true,
+		},
+		{
+			name:    "Too few args",
+			args:    args{"AAPL"},
+			want:    QuoteRequest{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseQuoteRequest(tt.args.csv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseQuoteRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseQuoteRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/quote_test.go
+++ b/quote_test.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/distributeddesigns/currency"
+)
+
+func TestQuote_ToCSV(t *testing.T) {
+	userID := "jappleseed"
+	stock := "AAPL"
+	tenD, _ := currency.NewFromFloat(10.0)
+	unixTime := time.Unix(123, 123456789)
+	cryptokey := "abc123="
+
+	type fields struct {
+		UserID    string
+		Stock     string
+		Price     currency.Currency
+		Timestamp time.Time
+		Cryptokey string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{userID, stock, tenD, unixTime, cryptokey},
+			want:   "jappleseed,AAPL,10.00,123123456,abc123=",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &Quote{
+				UserID:    tt.fields.UserID,
+				Stock:     tt.fields.Stock,
+				Price:     tt.fields.Price,
+				Timestamp: tt.fields.Timestamp,
+				Cryptokey: tt.fields.Cryptokey,
+			}
+			if got := q.ToCSV(); got != tt.want {
+				t.Errorf("Quote.ToCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseQuote(t *testing.T) {
+	userID := "jappleseed"
+	stock := "AAPL"
+	tenD, _ := currency.NewFromFloat(10.0)
+	unixTime := time.Unix(123, 123456000)
+	cryptokey := "abc123="
+
+	type args struct {
+		csv string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Quote
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{"jappleseed,AAPL,10.00,123123456,abc123="},
+			want: Quote{userID, stock, tenD, unixTime, cryptokey},
+		},
+		{
+			name:    "Too few args",
+			args:    args{"jappleseed,AAPL,10.00,123123456"},
+			wantErr: true,
+		},
+		{
+			name:    "Too many args",
+			args:    args{"jappleseed,AAPL,10.00,123123456,abc123=,hello!"},
+			wantErr: true,
+		},
+		{
+			name:    "Price stored as string",
+			args:    args{"jappleseed,AAPL,$10.00,123123456,abc123="},
+			wantErr: true,
+		},
+		{
+			name:    "Price stored as string",
+			args:    args{"jappleseed,AAPL,$10.00,123123456,abc123="},
+			wantErr: true,
+		},
+		{
+			name:    "Time stored as string",
+			args:    args{"jappleseed,AAPL,10.00,1970-01-01 00:02:03.123456789 +0000 UTC,abc123="},
+			wantErr: true,
+		},
+		// TODO: Pass this test!
+		// {
+		// 	name: "Time stored with extra precision",
+		// 	args: args{"jappleseed,AAPL,10.00,123123456789,abc123="},
+		// 	want: Quote{userID, stock, tenD, unixTime, cryptokey},
+		// },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseQuote(tt.args.csv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseQuote() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseQuote() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/quote_test.go
+++ b/quote_test.go
@@ -86,12 +86,7 @@ func TestParseQuote(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Price stored as string",
-			args:    args{"jappleseed,AAPL,$10.00,123123456,abc123="},
-			wantErr: true,
-		},
-		{
-			name:    "Time stored as string",
+			name:    "Time stored as formatted date",
 			args:    args{"jappleseed,AAPL,10.00,1970-01-01 00:02:03.123456789 +0000 UTC,abc123="},
 			wantErr: true,
 		},

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 Shared types
 ====
+[![Build Status](https://travis-ci.org/DistributedDesigns/shared_types.svg?branch=master)](https://travis-ci.org/DistributedDesigns/shared_types)
+
 Objects shared between services. Provides common serialization <-> deserialization. Particularly useful when passing objects via RMQ.

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,38 @@ Shared types
 [![Build Status](https://travis-ci.org/DistributedDesigns/shared_types.svg?branch=master)](https://travis-ci.org/DistributedDesigns/shared_types)
 
 Objects shared between services. Provides common serialization <-> deserialization. Particularly useful when passing objects via RMQ.
+
+#### `QuoteRequest`
+```go
+type QuoteRequest struct {
+	Stock  string
+	UserID string
+}
+
+qr := QuoteRequest{ "AAPL", "jappleseed"}
+
+qr.ToCSV() // "AAPL,jappleseed"
+
+qr2, error := ParseQuoteRequest("AAPL,jappleseed")
+```
+
+#### `Quote`
+- `Price` is serialized as a `float`
+- `Timestamp` is serialized as milliseconds from the epoch
+
+```go
+type Quote struct {
+	UserID    string
+	Stock     string
+	Price     currency.Currency
+	Timestamp time.Time
+	Cryptokey string
+}
+
+tenDollars, _ := currency.NewFromFloat(10.0)
+q := Quote{"jappleseed", "AAPL", tenDollars, time.Now(), "abc123="}
+
+q.ToCSV() // "jappleseed,AAPL,10.00,123123456,abc123="
+
+q2, error := ParseQuote("jappleseed,AAPL,10.00,123123456,abc123=")
+```


### PR DESCRIPTION
`Quote` and `QuoteRequest` can go CSV <-> `struct`

Structs will have to be serialized to be shared via RMQ. This should prevent every service from re-implementing the (de)serialization process. Also solves the problem of circular dependencies with shared structs. Later additions will include the auto-transaction messages, possibly command events