### PR TITLE
Tests for AutoTxs

### DIFF
--- a/autoTxCancel_test.go
+++ b/autoTxCancel_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAutoTxCancel_ToCSV(t *testing.T) {
+	type fields struct {
+		Stock    string
+		UserID   string
+		WorkerID uint64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{"AAPL", "jappleseed", 1},
+			want:   "AAPL,jappleseed,1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aTx := &AutoTxCancel{
+				Stock:    tt.fields.Stock,
+				UserID:   tt.fields.UserID,
+				WorkerID: tt.fields.WorkerID,
+			}
+			if got := aTx.ToCSV(); got != tt.want {
+				t.Errorf("AutoTxCancel.ToCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAutoTxCancel(t *testing.T) {
+	type args struct {
+		csv string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    AutoTxCancel
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{"AAPL,jappleseed,1"},
+			want: AutoTxCancel{"AAPL", "jappleseed", 1},
+		},
+		{
+			name:    "Empty string",
+			args:    args{""},
+			wantErr: true,
+		},
+		{
+			name:    "Too many args",
+			args:    args{"AAPL,jappleseed,1,hello!"},
+			wantErr: true,
+		},
+		{
+			name:    "Too few args",
+			args:    args{"AAPL,jappleseed"},
+			wantErr: true,
+		},
+		{
+			name:    "Doesn't accept string workerIDs",
+			args:    args{"AAPL,jappleseed,worker:1"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAutoTxCancel(tt.args.csv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAutoTxCancel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseAutoTxCancel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/autoTxInit.go
+++ b/autoTxInit.go
@@ -21,7 +21,15 @@ type AutoTxInit struct {
 
 // ToCSV : Converts the QuoteRequest to a csv
 func (aTx *AutoTxInit) ToCSV() string {
-	return fmt.Sprintf("%s,%s,%s,%s,%d", aTx.Amount.String(), aTx.Trigger.String(), aTx.Stock, aTx.UserID, aTx.WorkerID)
+	parts := make([]string, 5)
+
+	parts[0] = fmt.Sprintf("%0.2f", aTx.Amount.ToFloat())
+	parts[1] = fmt.Sprintf("%0.2f", aTx.Trigger.ToFloat())
+	parts[2] = aTx.Stock
+	parts[3] = aTx.UserID
+	parts[4] = strconv.FormatUint(aTx.WorkerID, 10)
+
+	return strings.Join(parts, ",")
 }
 
 // ParseAutoTxInit : Parses CSV as QuoteRequest

--- a/autoTxInit_test.go
+++ b/autoTxInit_test.go
@@ -1,0 +1,110 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	currency "github.com/distributeddesigns/currency"
+)
+
+const (
+	stock    = "AAPL"
+	userID   = "jappleseed"
+	workerID = uint64(1)
+)
+
+func TestAutoTxInit_ToCSV(t *testing.T) {
+	tenD, _ := currency.NewFromFloat(10.0)
+	fiveD, _ := currency.NewFromFloat(5.0)
+
+	type fields struct {
+		Amount   currency.Currency
+		Trigger  currency.Currency
+		Stock    string
+		UserID   string
+		WorkerID uint64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{tenD, fiveD, stock, userID, workerID},
+			want:   "10.00,5.00,AAPL,jappleseed,1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aTx := &AutoTxInit{
+				Amount:   tt.fields.Amount,
+				Trigger:  tt.fields.Trigger,
+				Stock:    tt.fields.Stock,
+				UserID:   tt.fields.UserID,
+				WorkerID: tt.fields.WorkerID,
+			}
+			if got := aTx.ToCSV(); got != tt.want {
+				t.Errorf("AutoTxInit.ToCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAutoTxInit(t *testing.T) {
+	tenD, _ := currency.NewFromFloat(10.0)
+	fiveD, _ := currency.NewFromFloat(5.0)
+
+	type args struct {
+		csv string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    AutoTxInit
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{"10.00,5.00,AAPL,jappleseed,1"},
+			want: AutoTxInit{tenD, fiveD, stock, userID, workerID},
+		},
+		{
+			name:    "Too many args",
+			args:    args{"10.00,5.00,AAPL,jappleseed,1,hello!"},
+			wantErr: true,
+		},
+		{
+			name:    "Too few args",
+			args:    args{"10.00,5.00,AAPL,jappleseed"},
+			wantErr: true,
+		},
+		{
+			name:    "Dollar signs in amount",
+			args:    args{"$10.00,5.00,AAPL,jappleseed,1"},
+			wantErr: true,
+		},
+		{
+			name:    "Dollar signs in trigger",
+			args:    args{"10.00,$5.00,AAPL,jappleseed,1"},
+			wantErr: true,
+		},
+		{
+			name:    "Worker id as key",
+			args:    args{"10.00,5.00,AAPL,jappleseed,worker:1"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAutoTxInit(tt.args.csv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAutoTxInit() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseAutoTxInit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
:100: Test coverage

Also fixes serialization error with currencies in AutoTxInit. @JakeCooper saw the work you were doing [here](https://github.com/DistributedDesigns/shared_types/blob/c116283379db89a2c4d53dab6ea20168a54e94a5/autoTxInit.go#L34) to fix this. The problem you're fixing, handling `$` in the deserialization, can be fixed on the serialization end instead.