### PR TITLE
Add AuditEvent

### DIFF
--- a/auditEvent.go
+++ b/auditEvent.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// AuditEvent is a serialization object that can be easily stored
+// in a database or ledger.
+type AuditEvent struct {
+	UserID    string
+	ID        uint64
+	EventType string
+	Content   string
+}
+
+const auditEventLen = 4
+
+// ToCSV serializes the AuditEvent as a CSV
+func (ae *AuditEvent) ToCSV() string {
+	parts := make([]string, auditEventLen)
+
+	parts[0] = ae.UserID
+	parts[1] = strconv.FormatUint(ae.ID, 10)
+	parts[2] = ae.EventType
+	parts[3] = ae.Content // TODO: Escape commas somehow?
+
+	return strings.Join(parts, ",")
+}
+
+// ParseAuditEvent attempts to parse a csv as an AuditEvent
+func ParseAuditEvent(csv string) (AuditEvent, error) {
+	parts := strings.Split(csv, ",")
+
+	if len(parts) != auditEventLen {
+		msg := fmt.Sprintf("Expected %d values in AuditEvent csv", auditEventLen)
+		return AuditEvent{}, errors.New(msg)
+	}
+
+	id, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return AuditEvent{}, err
+	}
+
+	return AuditEvent{
+		UserID:    parts[0],
+		ID:        id,
+		EventType: parts[2],
+		Content:   parts[3],
+	}, nil
+}

--- a/auditEvent_test.go
+++ b/auditEvent_test.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAuditEvent_ToCSV(t *testing.T) {
+	type fields struct {
+		UserID    string
+		ID        uint64
+		EventType string
+		Content   string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "Happy path",
+			fields: fields{"jappleseed", uint64(1), "command", "DO THIS NOW"},
+			want:   "jappleseed,1,command,DO THIS NOW",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := &AuditEvent{
+				UserID:    tt.fields.UserID,
+				ID:        tt.fields.ID,
+				EventType: tt.fields.EventType,
+				Content:   tt.fields.Content,
+			}
+			if got := ae.ToCSV(); got != tt.want {
+				t.Errorf("AuditEvent.ToCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAuditEvent(t *testing.T) {
+	type args struct {
+		csv string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    AuditEvent
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{"jappleseed,1,command,DO THIS NOW"},
+			want: AuditEvent{"jappleseed", uint64(1), "command", "DO THIS NOW"},
+		},
+		{
+			name:    "Too many args",
+			args:    args{"jappleseed,1,command,DO THIS NOW,what?"},
+			wantErr: true,
+		},
+		{
+			name:    "Too few args",
+			args:    args{"jappleseed,1,command"},
+			wantErr: true,
+		},
+		{
+			name:    "ID is string",
+			args:    args{"jappleseed,DEAD-BEEF,command,DO THIS NOW"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAuditEvent(tt.args.csv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAuditEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseAuditEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ qr := QuoteRequest{ "AAPL", "jappleseed", true, 1}
 
 qr.ToCSV() // "AAPL,jappleseed,true,1"
 
-qr2, error := ParseQuoteRequest("AAPL,jappleseed,true,1")
+qr2, err := ParseQuoteRequest("AAPL,jappleseed,true,1")
 ```
 
 #### `Quote`
@@ -38,5 +38,29 @@ q := Quote{tenDollars, "AAPL", "jappleseed", time.Now(), "abc123="}
 
 q.ToCSV() // "10.00,AAPL,jappleseed,123456789,abc123="
 
-q2, error := ParseQuote("10.00,AAPL,jappleseed,123456789,abc123=")
+q2, err := ParseQuote("10.00,AAPL,jappleseed,123456789,abc123=")
+```
+
+#### `AuditEvent`
+- Format for passing items through the `audit_event` RMQ channel
+- Should map to the columns in the `Logs` table
+- `EventType` should be an enum with entries
+	- `command`: User commands. One per transaction!
+	- `account_action`: Changes to a user's account state.
+	- `quote`: Shouldn't have to be used since quotes aren't logged using the `audit_event` RMQ channel
+- 'Content' can be the formatted xml for commands or quotes, or semi-structured text for account actions
+
+```go
+type AuditEvent struct {
+	UserID    string
+	ID        uint64
+	EventType string
+	Content   string
+}
+
+ae := AuditEvent{"jappleseed", uint64(1), "command", "DO THIS NOW"}
+
+ae.ToCSV() // "jappleseed,1,command,DO THIS NOW"
+
+ae2, err := ParseAuditEvent("jappleseed,1,command,DO THIS NOW")
 ```


### PR DESCRIPTION
Pass along useful values for creating events in the SQL audit log.

#11, #12 point out some missing features that aren't critical.